### PR TITLE
nats/task: set lastRev only when task is incomplete

### DIFF
--- a/task.go
+++ b/task.go
@@ -96,7 +96,6 @@ func NewNatsConditionTaskRepository(
 
 	// verify existing TaskID matches ConditionID and task is not active
 	if currTaskEntry != nil {
-		repo.lastRev = currTaskEntry.Revision()
 		currTask, err := condition.TaskFromMessage(currTaskEntry.Value())
 		if err != nil {
 			return nil, errors.Wrap(
@@ -126,6 +125,8 @@ func NewNatsConditionTaskRepository(
 					fmt.Sprintf("key: %s, error: %s", key, err.Error()),
 				)
 			}
+		} else {
+			repo.lastRev = currTaskEntry.Revision()
 		}
 	}
 

--- a/task_test.go
+++ b/task_test.go
@@ -110,6 +110,8 @@ func TestNewNatsConditionTaskRepository(t *testing.T) {
 				key := condition.TaskKVRepositoryKey(facilityCode, conditionKind, serverID)
 				_, err := taskRepo.kv.Get(key)
 				assert.ErrorIs(t, err, nats.ErrKeyNotFound)
+				// purged task has no revision set
+				assert.Zero(t, taskRepo.lastRev)
 			},
 		},
 		{


### PR DESCRIPTION
This ensures the subsequent Publish call will use create() instead of update()