### PR TITLE
Set controllerID for http based controllers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/metal-toolbox/conditionorc v1.1.1-0.20240805163108-b1c018c91b87
-	github.com/metal-toolbox/rivets v1.2.0
+	github.com/metal-toolbox/rivets v1.2.1-0.20240816124954-75fd3d3b2629
 	github.com/nats-io/nats-server/v2 v2.10.12
 	github.com/nats-io/nats.go v1.36.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,10 @@ github.com/metal-toolbox/fleetdb v1.19.3 h1:Dk7MVi5rS42a4OI46Ye/etg8R5hm1iajaI4U
 github.com/metal-toolbox/fleetdb v1.19.3/go.mod h1:v9agAzF7BhBBjA4rY+H2eZzQaBTEXO4b/Qikn4jmA7A=
 github.com/metal-toolbox/rivets v1.2.0 h1:QhN3tWH7NqKDqwRDYylxukw0mNQ/FkyvBYkwS0CJULE=
 github.com/metal-toolbox/rivets v1.2.0/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.2.1-0.20240815133456-3d065f11726e h1:UjTm+ot78ydNdmAS8nUoddwtTt4r85Xj9WKjZG92tGw=
+github.com/metal-toolbox/rivets v1.2.1-0.20240815133456-3d065f11726e/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.2.1-0.20240816124954-75fd3d3b2629 h1:Q9ssrrui7qwYDlv17k2NZQa2CiZ4irgzdo1Sq27Kpvg=
+github.com/metal-toolbox/rivets v1.2.1-0.20240816124954-75fd3d3b2629/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/publisher.go
+++ b/publisher.go
@@ -26,13 +26,16 @@ type PublisherHTTP struct {
 	taskRepository       *HTTPTaskRepository
 }
 
-func NewHTTPPublisher(serverID,
+func NewHTTPPublisher(
+	appName string,
+	serverID,
 	conditionID uuid.UUID,
 	conditionKind condition.Kind,
 	orcQueryor orc.Queryor,
 	logger *logrus.Logger) Publisher {
 	p := &PublisherHTTP{logger: logger}
 	httpStatusValuePublisher := NewHTTPConditionStatusPublisher(
+		appName,
 		serverID,
 		conditionID,
 		conditionKind,
@@ -43,6 +46,7 @@ func NewHTTPPublisher(serverID,
 	p.statusValuePublisher = httpStatusValuePublisher.(*HTTPConditionStatusPublisher)
 
 	httpTaskRepository := NewHTTPTaskRepository(
+		appName,
 		serverID,
 		conditionID,
 		conditionKind,

--- a/status_test.go
+++ b/status_test.go
@@ -524,6 +524,7 @@ func TestHTTPConditionStatusPublisher_Publish(t *testing.T) {
 	conditionKind := condition.FirmwareInstall
 
 	publisher := &HTTPConditionStatusPublisher{
+		controllerID:  registry.GetIDWithUUID("test", serverID),
 		conditionID:   conditionID,
 		conditionKind: conditionKind,
 		serverID:      serverID,

--- a/task_test.go
+++ b/task_test.go
@@ -611,6 +611,7 @@ func TestHTTPTaskRepository_Publish(t *testing.T) {
 	conditionKind := condition.FirmwareInstall
 
 	repo := &HTTPTaskRepository{
+		controllerID:  registry.GetIDWithUUID("test", serverID),
 		conditionID:   conditionID,
 		conditionKind: conditionKind,
 		serverID:      serverID,


### PR DESCRIPTION
The Orchestrator will only accept a StatusValue update payload with a valid controllerID,
this will also prove useful for when we decide that http based controllers are to publish liveness updates.

https://github.com/metal-toolbox/conditionorc/blob/4c65356c5bd38ef9b823a369ed625d0ad71212a5/internal/orchestrator/updates.go#L206

requires https://github.com/metal-toolbox/rivets/pull/88