### PR TITLE
publisher: attempt publishing both task, statusValue before returning an error

### DIFF
--- a/controller_http.go
+++ b/controller_http.go
@@ -179,7 +179,7 @@ func WithOrchestratorClient(c orc.Queryor) OptionHTTPController {
 	}
 }
 
-func (n *HTTPController) traceSpaceContextFromValues(traceID, spanID string) (trace.SpanContext, error) {
+func traceSpaceContextFromValues(traceID, spanID string) (trace.SpanContext, error) {
 	// extract traceID and spanID
 	pTraceID, _ := trace.TraceIDFromHex(traceID)
 	pSpanID, _ := trace.SpanIDFromHex(spanID)
@@ -230,7 +230,7 @@ func (n *HTTPController) Run(ctx context.Context, handler TaskHandler) error {
 	}
 
 	// set remote span context
-	remoteSpanCtx, err := n.traceSpaceContextFromValues(task.TraceID, task.SpanID)
+	remoteSpanCtx, err := traceSpaceContextFromValues(task.TraceID, task.SpanID)
 	if err != nil {
 		n.logger.Debug(err.Error())
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/metal-toolbox/conditionorc v1.1.1-0.20240805163108-b1c018c91b87
-	github.com/metal-toolbox/rivets v1.3.3
+	github.com/metal-toolbox/rivets v1.3.5
 	github.com/nats-io/nats-server/v2 v2.10.12
 	github.com/nats-io/nats.go v1.36.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/metal-toolbox/conditionorc v1.1.1-0.20240805163108-b1c018c91b87
-	github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25
+	github.com/metal-toolbox/rivets v1.3.6
 	github.com/nats-io/nats-server/v2 v2.10.12
 	github.com/nats-io/nats.go v1.36.0
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/google/uuid v1.6.0
 	github.com/metal-toolbox/conditionorc v1.1.1-0.20240805163108-b1c018c91b87
-	github.com/metal-toolbox/rivets v1.3.5
+	github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25
 	github.com/nats-io/nats-server/v2 v2.10.12
 	github.com/nats-io/nats.go v1.36.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -529,6 +529,8 @@ github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0 h1:IJlBEwzi
 github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25 h1:z6gipdqU9pkHDHeNb0hmwtR3+zOpaWDIuDLDVHALnk8=
 github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.6 h1:iw1KlhNcK8ZIHnBGwKeqtYInyN/prhiblb6qE+FhzH0=
+github.com/metal-toolbox/rivets v1.3.6/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,8 @@ github.com/metal-toolbox/fleetdb v1.19.3 h1:Dk7MVi5rS42a4OI46Ye/etg8R5hm1iajaI4U
 github.com/metal-toolbox/fleetdb v1.19.3/go.mod h1:v9agAzF7BhBBjA4rY+H2eZzQaBTEXO4b/Qikn4jmA7A=
 github.com/metal-toolbox/rivets v1.3.3 h1:bHd2HRh/uc3zb2bughpuidW2lUQOXrFRRDWBWwqMQWw=
 github.com/metal-toolbox/rivets v1.3.3/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.5 h1:lnwnREBjsmgicseLlCoGIr/e+vtxwH5LXDE2ol+HJws=
+github.com/metal-toolbox/rivets v1.3.5/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/go.sum
+++ b/go.sum
@@ -525,6 +525,10 @@ github.com/metal-toolbox/rivets v1.3.3 h1:bHd2HRh/uc3zb2bughpuidW2lUQOXrFRRDWBWw
 github.com/metal-toolbox/rivets v1.3.3/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/metal-toolbox/rivets v1.3.5 h1:lnwnREBjsmgicseLlCoGIr/e+vtxwH5LXDE2ol+HJws=
 github.com/metal-toolbox/rivets v1.3.5/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0 h1:IJlBEwziIPEfhjZdwIFUYzPPS7xlWlxznPXqmrQ67/0=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902121434-587072fc4bc0/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25 h1:z6gipdqU9pkHDHeNb0hmwtR3+zOpaWDIuDLDVHALnk8=
+github.com/metal-toolbox/rivets v1.3.6-0.20240902123133-a36024eb7d25/go.mod h1:i78a1x0w2uNyMlvUgyO6ST552u9wV2Xa4+A73oA4WJY=
 github.com/microsoft/go-mssqldb v0.17.0/go.mod h1:OkoNGhGEs8EZqchVTtochlXruEhEOaO4S0d2sB5aeGQ=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/publisher.go
+++ b/publisher.go
@@ -63,15 +63,15 @@ func NewHTTPPublisher(
 func (p *PublisherHTTP) Publish(ctx context.Context, task *condition.Task[any, any], tsUpdateOnly bool) error {
 	var err error
 
-	if errSV := p.taskRepository.Publish(ctx, task, tsUpdateOnly); errSV != nil {
-		p.logger.WithError(errSV).Error("Task publish error")
-		err = errors.Join(err, errSV)
+	if errTask := p.taskRepository.Publish(ctx, task, tsUpdateOnly); errTask != nil {
+		p.logger.WithError(errTask).Error("Task publish error")
+		err = errors.Join(err, errTask)
 	}
 
-	errTask := p.statusValuePublisher.Publish(ctx, task.Server.ID, task.State, task.Status.MustMarshal(), tsUpdateOnly)
-	if errTask != nil {
-		p.logger.WithError(errTask).Error("Status Value publish error")
-		err = errors.Join(err, errTask)
+	errSV := p.statusValuePublisher.Publish(ctx, task.Server.ID, task.State, task.Status.MustMarshal(), tsUpdateOnly)
+	if errSV != nil {
+		p.logger.WithError(errSV).Error("Status Value publish error")
+		err = errors.Join(err, errSV)
 	}
 
 	return err


### PR DESCRIPTION
- Ensure the task, status value updates are published regardless of a failure in either.
- The Condition gets finalized in active-conditions as soon as status value includes a final state, this would prevent the Task from being updated since the condition is no longer active.
- Setup the traceID, spanID from the condition payload.

 Long term Status Value KV is to be replaced by the Task KV, until this this arrangement lets us work with both.